### PR TITLE
Spanish Translation

### DIFF
--- a/es-ES/MerchantHelp_es_ES.lang
+++ b/es-ES/MerchantHelp_es_ES.lang
@@ -1,8 +1,8 @@
 language.code=es-ES
 language=Español
 //TODO Translate [Reference] 'If you want to ^c:d03e37;sell^c:pop; that item of yours...'
-staxel.village.dialogue.MerchantHelp.line:10000100=
+staxel.village.dialogue.MerchantHelp.line:10000100=Si quieres ^c:d03e37;vender^c:pop; ese objeto que tienes...
 //TODO Translate [Reference] 'Just place it on the ^c:d03e37;sell table^c:pop;, then ^c:d03e37;interact^c:pop; with the table itself!'
-staxel.village.dialogue.MerchantHelp.line:10000200=
+staxel.village.dialogue.MerchantHelp.line:10000200=Sólo colocalo en el ^c:d03e37;mostrador^c:pop; ¡Luego ^c:d03e37;interactua^c:pop; con ella!
 //TODO Translate [Reference] 'I'll give you ^c:d03e37;petals^c:pop; in return!'
-staxel.village.dialogue.MerchantHelp.line:10000300=
+staxel.village.dialogue.MerchantHelp.line:10000300=¡Te daré ^c:d03e37;petalos^c:pop; a cambio!

--- a/es-ES/NerdGeneral_es_ES.lang
+++ b/es-ES/NerdGeneral_es_ES.lang
@@ -1,122 +1,122 @@
 language.code=es-ES
 language=Español
 //TODO Translate [Reference] 'Did you hear about that new console?'
-staxel.village.dialogue.Nerd.line:10000100=
+staxel.village.dialogue.Nerd.line:10000100=¿Escuchaste sobre esa nueva consola?
 //TODO Translate [Reference] 'They say it only manages one teraflop...'
-staxel.village.dialogue.Nerd.line:10000200=
+staxel.village.dialogue.Nerd.line:10000200=Dicen que sólo soporta un teraflop...
 //TODO Translate [Reference] 'Do you think it will be worth the investment?'
-staxel.village.dialogue.Nerd.line:10000300=
+staxel.village.dialogue.Nerd.line:10000300=¿Crees que valga la pena la inversión?
 //TODO Translate [Reference] 'Have you seen any rare monsters around town?'
-staxel.village.dialogue.Nerd.line:10000400=
+staxel.village.dialogue.Nerd.line:10000400=¿Haz visto algún monstruo raro por los alrededores del pueblo?
 //TODO Translate [Reference] 'No, no, not real monsters... you know what, never mind.'
-staxel.village.dialogue.Nerd.line:10000500=
+staxel.village.dialogue.Nerd.line:10000500=No, no, monstruos reales no... ¿Sabes qué? olvidalo.
 //TODO Translate [Reference] 'I'd love to go to one of those game conferences someday.'
-staxel.village.dialogue.Nerd.line:10000600=
+staxel.village.dialogue.Nerd.line:10000600=Me gustaría ir a una de esas conferencias de videojuegos algún día.
 //TODO Translate [Reference] 'We're so far away from civilisation out here...'
-staxel.village.dialogue.Nerd.line:10000700=
+staxel.village.dialogue.Nerd.line:10000700=Estamos muy alejados de la civilización aquí...
 //TODO Translate [Reference] 'No matter how many times I try, I can never get the characters I want...'
-staxel.village.dialogue.Nerd.line:10000800=
+staxel.village.dialogue.Nerd.line:10000800=No importa cuantas veces lo intente, jamás consigo los personajes que quiero... 
 //TODO Translate [Reference] 'I don't know why I keep playing these phone games.'
-staxel.village.dialogue.Nerd.line:10000900=
+staxel.village.dialogue.Nerd.line:10000900=No sé por qué sigo jugando estos juegos para el móvil.
 //TODO Translate [Reference] 'Someday, I want to make my own game. I have the budget after all!'
-staxel.village.dialogue.Nerd.line:10001000=
+staxel.village.dialogue.Nerd.line:10001000=Algún día quiero hacer mi propio juego ¡Tengo el presupuesto, despues de todo!
 //TODO Translate [Reference] 'I've been planning it for years now.'
-staxel.village.dialogue.Nerd.line:10001100=
+staxel.village.dialogue.Nerd.line:10001100=Tengo años planeandolo
 //TODO Translate [Reference] 'I have a six hundred page design document hidden away!'
-staxel.village.dialogue.Nerd.line:10001200=
+staxel.village.dialogue.Nerd.line:10001200=¡Tengo un documento de seiscientas páginas con el diseño escondido por ahí!
 //TODO Translate [Reference] 'All I have to do now is learn how to program it...'
-staxel.village.dialogue.Nerd.line:10001300=
+staxel.village.dialogue.Nerd.line:10001300=Todo lo que tengo que hacer ahora es aprender a programarlo...
 //TODO Translate [Reference] '^c:1486b0;{0-s_name}^c:pop; can be pretty stubborn sometimes...'
-staxel.village.dialogue.Nerd.line:10001400=
+staxel.village.dialogue.Nerd.line:10001400=^c:1486b0;{0-s_name}^c:pop; puede ser algo terco a veces...
 //TODO Translate [Reference] 'All I want is to try out the time machine!'
-staxel.village.dialogue.Nerd.line:10001500=
+staxel.village.dialogue.Nerd.line:10001500=¡Todo lo que quiero es probar la máquina del tiempo!
 //TODO Translate [Reference] 'I even offered to pay good money for the chance!'
-staxel.village.dialogue.Nerd.line:10001600=
+staxel.village.dialogue.Nerd.line:10001600=¡Incluso he ofrecido pagar una buena suma de dinero por la oportunidad!
 //TODO Translate [Reference] 'I refuse to believe it doesn't exist!'
-staxel.village.dialogue.Nerd.line:10001700=
+staxel.village.dialogue.Nerd.line:10001700=¡Me niego a creer que no existe!
 //TODO Translate [Reference] 'Wouldn't it be cool if there was a scientist around here?'
-staxel.village.dialogue.Nerd.line:10001800=
+staxel.village.dialogue.Nerd.line:10001800=¿No sería genial si hubiera un científico por aquí?
 //TODO Translate [Reference] 'Some sort of professor with all kinds of wacky gadgets!'
-staxel.village.dialogue.Nerd.line:10001900=
+staxel.village.dialogue.Nerd.line:10001900=¡Una especie de profesor con todo tipo de aparatos locos!
 //TODO Translate [Reference] 'Maybe they'd help me build my dream super robot!'
-staxel.village.dialogue.Nerd.line:10002000=
+staxel.village.dialogue.Nerd.line:10002000=¡Quizás me ayudarían a construir el super robot de mis sueños!
 //TODO Translate [Reference] 'The new expansion for my favourite MMO is launching soon!'
-staxel.village.dialogue.Nerd.line:10002100=
+staxel.village.dialogue.Nerd.line:10002100=¡La nueva expansión de mi MMO favorito saldrá pronto!
 //TODO Translate [Reference] 'I can't wait!'
-staxel.village.dialogue.Nerd.line:10002200=
+staxel.village.dialogue.Nerd.line:10002200=¡No puedo esperar!
 //TODO Translate [Reference] 'I just hope they don't turn it into a gear treadmill again...'
-staxel.village.dialogue.Nerd.line:10002300=
+staxel.village.dialogue.Nerd.line:10002300=Sólo espero que no lo conviertan en una busqueda absurda de armaduras y equipamientos de nuevo...
 //TODO Translate [Reference] 'One of my online friends recommended a new book series to me.'
-staxel.village.dialogue.Nerd.line:10002400=
+staxel.village.dialogue.Nerd.line:10002400=Uno de mis amigos en linea me recomendó una nueva saga de libros.
 //TODO Translate [Reference] 'I really can't remember what it was called though...'
-staxel.village.dialogue.Nerd.line:10002500=
+staxel.village.dialogue.Nerd.line:10002500=Aunque realmente no recuerdo como se llamaba...
 //TODO Translate [Reference] 'M-M- I think it started with M?'
-staxel.village.dialogue.Nerd.line:10002600=
+staxel.village.dialogue.Nerd.line:10002600=¿M-M- Creo que empezaba con M?
 //TODO Translate [Reference] 'Mist...something?'
-staxel.village.dialogue.Nerd.line:10002700=
+staxel.village.dialogue.Nerd.line:10002700=Mist...¿Algo así?
 //TODO Translate [Reference] 'Why do I choose to play female characters in games?'
-staxel.village.dialogue.Nerd.line:10002800=
+staxel.village.dialogue.Nerd.line:10002800=¿Por qué escojo jugar con personajes femeninos en los videojuegos?
 //TODO Translate [Reference] 'I get asked that a lot actually.'
-staxel.village.dialogue.Nerd.line:10002900=
+staxel.village.dialogue.Nerd.line:10002900=Me preguntan eso todo el tiempo, de hecho.
 //TODO Translate [Reference] 'My answer is simple...'
-staxel.village.dialogue.Nerd.line:10003000=
+staxel.village.dialogue.Nerd.line:10003000=Mi respuesta es simple...
 //TODO Translate [Reference] 'Well, why not?'
-staxel.village.dialogue.Nerd.line:10003100=
+staxel.village.dialogue.Nerd.line:10003100=Bueno ¿Por qué no?
 //TODO Translate [Reference] 'Do you have a favourite boat?'
-staxel.village.dialogue.Nerd.line:10003200=
+staxel.village.dialogue.Nerd.line:10003200=¿Tienes algún bote favorito?
 //TODO Translate [Reference] 'It's been a hot topic online for ages!'
-staxel.village.dialogue.Nerd.line:10003300=
+staxel.village.dialogue.Nerd.line:10003300=¡Ha sido un tema muy popular en linea por mucho tiempo!
 //TODO Translate [Reference] 'Mine's the Shimakaze by the way!'
-staxel.village.dialogue.Nerd.line:10003400=
+staxel.village.dialogue.Nerd.line:10003400=¡El mío es el Shimakaze, por cierto!
 //TODO Translate [Reference] 'The Amatsukaze is pretty cool too I suppose...'
-staxel.village.dialogue.Nerd.line:10003500=
+staxel.village.dialogue.Nerd.line:10003500=El Amatsukaze es muy genial también, supongo...
 //TODO Translate [Reference] ''Please look forward to it!''
-staxel.village.dialogue.Nerd.line:10003600=
+staxel.village.dialogue.Nerd.line:10003600=¡Por favor, anticipalo con ansias!
 //TODO Translate [Reference] 'That's what he said...'
-staxel.village.dialogue.Nerd.line:10003700=
+staxel.village.dialogue.Nerd.line:10003700=Eso fue lo que ella dijo...
 //TODO Translate [Reference] 'What a joke.'
-staxel.village.dialogue.Nerd.line:10003800=
+staxel.village.dialogue.Nerd.line:10003800=Qué chiste.
 //TODO Translate [Reference] 'That was the worst reveal stream yet.'
-staxel.village.dialogue.Nerd.line:10003900=
+staxel.village.dialogue.Nerd.line:10003900=Esa fue la peor revelación transmitida en vivo hasta ahora.
 //TODO Translate [Reference] 'People keep telling me the new Game of Seats book is coming soon.'
-staxel.village.dialogue.Nerd.line:10004000=
+staxel.village.dialogue.Nerd.line:10004000=La gente sigue diciendome que el nuevo libro de Juego De Asientos saldrá pronto.
 //TODO Translate [Reference] 'That's the TV series!'
-staxel.village.dialogue.Nerd.line:10004100=
+staxel.village.dialogue.Nerd.line:10004100=¡Esa es la serie de televisión!
 //TODO Translate [Reference] 'Not the book!'
-staxel.village.dialogue.Nerd.line:10004200=
+staxel.village.dialogue.Nerd.line:10004200=¡No el libro!
 //TODO Translate [Reference] 'The TV series! At least get them right!'
-staxel.village.dialogue.Nerd.line:10004300=
+staxel.village.dialogue.Nerd.line:10004300=¡La serie de televisión! ¡Al menos diganlo correctamente!
 //TODO Translate [Reference] 'My favourite manga keeps going on hiatus.'
-staxel.village.dialogue.Nerd.line:10004400=
+staxel.village.dialogue.Nerd.line:10004400=Mi manga favorito sigue entrando en fase de hiatus.
 //TODO Translate [Reference] 'It's been months now.'
-staxel.village.dialogue.Nerd.line:10004500=
+staxel.village.dialogue.Nerd.line:10004500=Ya han pasado meses.
 //TODO Translate [Reference] 'It comes off hiatus. Then goes back on hiatus a few days later.'
-staxel.village.dialogue.Nerd.line:10004600=
+staxel.village.dialogue.Nerd.line:10004600=Sale de hiatus. Luego vuelve al hiatus pocos días después.
 //TODO Translate [Reference] 'I don't even care any more. I just want it to end!'
-staxel.village.dialogue.Nerd.line:10004700=
+staxel.village.dialogue.Nerd.line:10004700=Ya ni siquiera me importa ¡Sólo quiero que acabe!
 //TODO Translate [Reference] 'Imagine being able to finish off monsters in one punch!'
-staxel.village.dialogue.Nerd.line:10004800=
+staxel.village.dialogue.Nerd.line:10004800=¡Imagina poder ser capaz de derrotar a un monstruo de un solo golpe!
 //TODO Translate [Reference] 'That would be my dream super power!'
-staxel.village.dialogue.Nerd.line:10004900=
+staxel.village.dialogue.Nerd.line:10004900=¡Ese sería el super poder de mis sueños!
 //TODO Translate [Reference] 'Now to just wait until I get pulled into another world!'
-staxel.village.dialogue.Nerd.line:10005000=
+staxel.village.dialogue.Nerd.line:10005000=¡Sólo queda esperar a que me lleven a otro mundo!
 //TODO Translate [Reference] 'Just one more card!'
-staxel.village.dialogue.Nerd.line:10005100=
+staxel.village.dialogue.Nerd.line:10005100=¡Sólo una carta más!
 //TODO Translate [Reference] 'I only need one more card to finish off my collection!'
-staxel.village.dialogue.Nerd.line:10005200=
+staxel.village.dialogue.Nerd.line:10005200=¡Tan sólo necesito una carta más para terminar mi colección!
 //TODO Translate [Reference] 'The problem is it's a super rare promotional card...'
-staxel.village.dialogue.Nerd.line:10005300=
+staxel.village.dialogue.Nerd.line:10005300=El problema es que es una carta promocional super rara...
 //TODO Translate [Reference] 'No matter how much I'm willing to pay...'
-staxel.village.dialogue.Nerd.line:10005400=
+staxel.village.dialogue.Nerd.line:10005400=No importa cuanto esté dispuesto a pagar...
 //TODO Translate [Reference] 'I can't do much if no one is selling...'
-staxel.village.dialogue.Nerd.line:10005500=
+staxel.village.dialogue.Nerd.line:10005500=No puedo hacer mucho si nadie la está vendiendo...
 //TODO Translate [Reference] 'HB might be my favourite character of all time now...'
-staxel.village.dialogue.Nerd.line:10005600=
+staxel.village.dialogue.Nerd.line:10005600=Puede que ahora HB sea mi personaje favorito de todos los tiempo...
 //TODO Translate [Reference] 'I played through the whole game in one sitting!'
-staxel.village.dialogue.Nerd.line:10005700=
+staxel.village.dialogue.Nerd.line:10005700=¡Pasé todo el juego en una sentada!
 //TODO Translate [Reference] 'She's so perfect!'
-staxel.village.dialogue.Nerd.line:10005800=
+staxel.village.dialogue.Nerd.line:10005800=¡Ella es tan perfecta!
 //TODO Translate [Reference] 'All the forums I frequent are flooded with fanart these days...'
-staxel.village.dialogue.Nerd.line:10005900=
+staxel.village.dialogue.Nerd.line:10005900=En estos días todos los foros que suelo visitar están inundados con fanart...
 //TODO Translate [Reference] 'I just want to have good discussions and talk theories!'
-staxel.village.dialogue.Nerd.line:10006000=
+staxel.village.dialogue.Nerd.line:10006000=¡Sólo quiero tener buenos debates y hablar sobre teorías!

--- a/es-ES/NerdTheft_es_ES.lang
+++ b/es-ES/NerdTheft_es_ES.lang
@@ -1,6 +1,6 @@
 language.code=es-ES
 language=Español
 //TODO Translate [Reference] 'They're saying there's a thief in town!'
-staxel.village.dialogue.NerdTheft.line:10000100=
+staxel.village.dialogue.NerdTheft.line:10000100=¡Dicen que hay un ladrón en el pueblo!
 //TODO Translate [Reference] 'If only superheroes were real...'
-staxel.village.dialogue.NerdTheft.line:10000200=
+staxel.village.dialogue.NerdTheft.line:10000200=Si tan solo los superheroes fueran reales...

--- a/es-ES/OrderlyGeneral_es_ES.lang
+++ b/es-ES/OrderlyGeneral_es_ES.lang
@@ -1,46 +1,46 @@
 language.code=es-ES
 language=Español
 //TODO Translate [Reference] 'Why are the paths around here always so dirty?'
-staxel.village.dialogue.Orderly.line:10000100=
+staxel.village.dialogue.Orderly.line:10000100=¿Por qué los caminos siempre estan tan sucios por aquí?
 //TODO Translate [Reference] 'It's like no one ever tidies up...'
-staxel.village.dialogue.Orderly.line:10000200=
+staxel.village.dialogue.Orderly.line:10000200=Es como si nadie organizara nada...
 //TODO Translate [Reference] 'If I was mayor I wouldn't leave all those papers lying around...'
-staxel.village.dialogue.Orderly.line:10000300=
+staxel.village.dialogue.Orderly.line:10000300=Si fuera el alcalde no dejaría todos esos papeles en el suelo...
 //TODO Translate [Reference] 'How do they stay in order?'
-staxel.village.dialogue.Orderly.line:10000400=
+staxel.village.dialogue.Orderly.line:10000400=¿Cómo se mantienen ordenados?
 //TODO Translate [Reference] 'No one around here seems to take their shoes off indoors.'
-staxel.village.dialogue.Orderly.line:10000500=
+staxel.village.dialogue.Orderly.line:10000500=Nadie por aquí parece quitarse los zapatos al llegar a casa.
 //TODO Translate [Reference] 'Then again, I guess I'm guilty of that too...'
-staxel.village.dialogue.Orderly.line:10000600=
+staxel.village.dialogue.Orderly.line:10000600=Pero claro, supongo que es mi culpa también...
 //TODO Translate [Reference] 'I always carry a ^c:d03e37;broom^c:pop; around with me.'
-staxel.village.dialogue.Orderly.line:10000700=
+staxel.village.dialogue.Orderly.line:10000700=Siembre cargo una ^c:d03e37;escoba^c:pop; conmigo.
 //TODO Translate [Reference] 'You never know when it might come in handy!'
-staxel.village.dialogue.Orderly.line:10000800=
+staxel.village.dialogue.Orderly.line:10000800=¡Nunca se sabe cuando pueda hacer falta!
 //TODO Translate [Reference] 'There are far too many youngsters in this town...'
-staxel.village.dialogue.Orderly.line:10000900=
+staxel.village.dialogue.Orderly.line:10000900=Hay demasiados jóvenes en este pueblo...
 //TODO Translate [Reference] 'It's hard to find anyone who shares my concerns.'
-staxel.village.dialogue.Orderly.line:10001000=
+staxel.village.dialogue.Orderly.line:10001000=Es difícil conseguir a alguién que tenga las mismas preocupaciones que yo.
 //TODO Translate [Reference] 'Just a few more seasons and I'll be all set!'
-staxel.village.dialogue.Orderly.line:10001100=
+staxel.village.dialogue.Orderly.line:10001100=¡Sólo unas pocas temporadas más y estaré listo!
 //TODO Translate [Reference] 'My campaign is in its final stages of preparation.'
-staxel.village.dialogue.Orderly.line:10001200=
+staxel.village.dialogue.Orderly.line:10001200=Mi campaña está en su fase final de preparación.
 //TODO Translate [Reference] 'I just need to secure the support of a few more influential residents...'
-staxel.village.dialogue.Orderly.line:10001300=
+staxel.village.dialogue.Orderly.line:10001300=Sólo necesito asegurarme de contar con el apoyo de algunos residentes influenciales...
 //TODO Translate [Reference] 'I'll make sure this village stays clean!'
-staxel.village.dialogue.Orderly.line:10001400=
+staxel.village.dialogue.Orderly.line:10001400=¡Me aseguraré de que esta villa se mantenga limpia!
 //TODO Translate [Reference] 'Every morning I'm forced to confront a horrible truth...'
-staxel.village.dialogue.Orderly.line:10001500=
+staxel.village.dialogue.Orderly.line:10001500=Cada mañana me veo forzado a enfrentar un realidad horrible...
 //TODO Translate [Reference] 'Our streets are not straight enough.'
-staxel.village.dialogue.Orderly.line:10001600=
+staxel.village.dialogue.Orderly.line:10001600=Nuestras calles no son lo suficientemente ordenadas.
 //TODO Translate [Reference] 'I'd really like to talk to our town planner...'
-staxel.village.dialogue.Orderly.line:10001700=
+staxel.village.dialogue.Orderly.line:10001700=De verdad me gustaría hablar con nuestro urbanista...
 //TODO Translate [Reference] 'The town's layout is a mess! Not orderly at all!'
-staxel.village.dialogue.Orderly.line:10001800=
+staxel.village.dialogue.Orderly.line:10001800=¡El diseño del pueblo es un desastre! ¡Para nada ordenado!
 //TODO Translate [Reference] 'I would suggest aligning tiles carefully when you decorate.'
-staxel.village.dialogue.Orderly.line:10001900=
+staxel.village.dialogue.Orderly.line:10001900=Sugeriría alinear las baldosas cuidadosamentes cuando se decore.
 //TODO Translate [Reference] 'One resident accidentally placed the wrong tile in the plaza...'
-staxel.village.dialogue.Orderly.line:10002000=
+staxel.village.dialogue.Orderly.line:10002000=Un habitante colocó accidentalmente la baldosa incorrecta en la plaza...
 //TODO Translate [Reference] 'He disappeared the following night and was never heard from again.'
-staxel.village.dialogue.Orderly.line:10002100=
+staxel.village.dialogue.Orderly.line:10002100=Desapareció la noche siguiente y jamás supimos de él de nuevo.
 //TODO Translate [Reference] 'Just a friendly warning.'
-staxel.village.dialogue.Orderly.line:10002200=
+staxel.village.dialogue.Orderly.line:10002200=Sólo estoy advirtiendo.

--- a/es-ES/PatisserieMissing_es_ES.lang
+++ b/es-ES/PatisserieMissing_es_ES.lang
@@ -1,42 +1,42 @@
 language.code=es-ES
 language=Español
 //TODO Translate [Reference] 'Sadly, the ^c:1486b0;patisserie^c:pop; is currently closed for renovations.'
-staxel.village.dialogue.job.PatisserieMissing.line:10000100=
+staxel.village.dialogue.job.PatisserieMissing.line:10000100=Lamentablemente, la ^c:1486b0;pastelería^c:pop; está cerrada en estos momentos por remodelaciones.
 //TODO Translate [Reference] 'If only someone could finish the job I'd reopen...'
-staxel.village.dialogue.job.PatisserieMissing.line:10000200=
+staxel.village.dialogue.job.PatisserieMissing.line:10000200=Volvería a abrir si tan sólo alguien pudiera terminar el trabajo
 //TODO Translate [Reference] 'Why did someone vandalise the ^c:1486b0;patisserie^c:pop;?'
-staxel.village.dialogue.job.PatisserieMissing.line:10000300=
+staxel.village.dialogue.job.PatisserieMissing.line:10000300=¿Por qué alguien vandalizó la ^c:1486b0;pastelería^c:pop;?
 //TODO Translate [Reference] 'I can already feel my icing skills begin to rust...'
-staxel.village.dialogue.job.PatisserieMissing.line:10000400=
+staxel.village.dialogue.job.PatisserieMissing.line:10000400=Ya puedo sentir cómo se oxidan mis habilidades de glaseado...
 //TODO Translate [Reference] 'If this keeps up I'll end up icing the town instead!'
-staxel.village.dialogue.job.PatisserieMissing.line:10000500=
+staxel.village.dialogue.job.PatisserieMissing.line:10000500=¡Si esto sigue así terminaré glaseando todo el pueblo!
 //TODO Translate [Reference] 'A town with out a ^c:1486b0;patisserie^c:pop; is like a cake without icing.'
-staxel.village.dialogue.job.PatisserieMissing.line:10000600=
+staxel.village.dialogue.job.PatisserieMissing.line:10000600=Un pueblo sin ^c:1486b0;pastelería^c:pop; es como un pastel sin contorno. 
 //TODO Translate [Reference] '{0-playername}, won't you consider building me a ^c:1486b0;patisserie^c:pop;?'
-staxel.village.dialogue.job.PatisserieMissing.line:10000700=
+staxel.village.dialogue.job.PatisserieMissing.line:10000700=¿{0-playername}, por qué no consideras construirme una ^c:1486b0;pastelería^c:pop;?
 //TODO Translate [Reference] 'I can give you this ^c:d03e37;signpost^c:pop; to get you started.'
-staxel.village.dialogue.job.PatisserieMissing.line:10000800=
+staxel.village.dialogue.job.PatisserieMissing.line:10000800=Puedo darte este ^c:d03e37;letrero^c:pop; para empezar.
 //TODO Translate [Reference] 'Place it at the front of the building for me!'
-staxel.village.dialogue.job.PatisserieMissing.line:10000900=
+staxel.village.dialogue.job.PatisserieMissing.line:10000900=¡Colócamela al frente del edificio! 
 //TODO Translate [Reference] 'That way everyone will know where to find us once it's built!'
-staxel.village.dialogue.job.PatisserieMissing.line:10001000=
+staxel.village.dialogue.job.PatisserieMissing.line:10001000=¡Así todos sabrán dónde encontrarnos una vez que esté hecha!
 //TODO Translate [Reference] 'Oh, how I'd love to be able to bake again...'
-staxel.village.dialogue.job.PatisserieMissing.line:10001100=
+staxel.village.dialogue.job.PatisserieMissing.line:10001100=Oh, cuánto me gustaría poder hornear de nuevo...
 //TODO Translate [Reference] 'It sounds like the ^c:d03e37;patisserie signpost^c:pop; has gone missing...'
-staxel.village.dialogue.job.PatisserieMissing.line:10001200=
+staxel.village.dialogue.job.PatisserieMissing.line:10001200=Parece que el ^c:d03e37;letrero de la pastelería^c:pop; se ha perdido...
 //TODO Translate [Reference] 'I can get you another, but it's going to cost you {0-currency}{1-sign}. How's that?'
-staxel.village.dialogue.job.PatisserieMissing.line:10001300=
+staxel.village.dialogue.job.PatisserieMissing.line:10001300=Puedo conseguirte otro pero te costaría {0-currency}{1-sign} ¿Qué te parece?
 //TODO Translate [Reference] 'You're a lifesaver!'
-staxel.village.dialogue.job.PatisserieMissing.line:10001400=
+staxel.village.dialogue.job.PatisserieMissing.line:10001400=¡Acabas de salva mi vida!
 //TODO Translate [Reference] 'I think I know where it is...'
-staxel.village.dialogue.job.PatisserieMissing.line:10001500=
+staxel.village.dialogue.job.PatisserieMissing.line:10001500=Creo que sé dónde está...
 //TODO Translate [Reference] 'Oh, that's good to hear!'
-staxel.village.dialogue.job.PatisserieMissing.line:10001600=
+staxel.village.dialogue.job.PatisserieMissing.line:10001600=¡Oh, qué bueno escuchar eso!
 //TODO Translate [Reference] 'I hope to see a wonderful patisserie soon!'
-staxel.village.dialogue.job.PatisserieMissing.line:10001700=
+staxel.village.dialogue.job.PatisserieMissing.line:10001700=¡Espero poder ver una pastelería maravillosa muy pronto!
 //TODO Translate [Reference] 'Oh dear... It looks like you don't have enough petals...'
-staxel.village.dialogue.job.PatisserieMissing.line:10001800=
+staxel.village.dialogue.job.PatisserieMissing.line:10001800=Oh, cielos... Parece que no tienes suficientes pétalos...
 //TODO Translate [Reference] 'Don't worry! I'll hold on to it until you can afford it!'
-staxel.village.dialogue.job.PatisserieMissing.line:10001900=
+staxel.village.dialogue.job.PatisserieMissing.line:10001900=¡No te preocupes! ¡Me quedaré con esto hasta que puedas pagarlo!
 //TODO Translate [Reference] 'Okay! Here it is!'
-staxel.village.dialogue.job.PatisserieMissing.line:10002000=
+staxel.village.dialogue.job.PatisserieMissing.line:10002000=¡Muy bién! ¡Aquí tienes!

--- a/es-ES/PatissierJob_es_ES.lang
+++ b/es-ES/PatissierJob_es_ES.lang
@@ -1,52 +1,52 @@
 language.code=es-ES
 language=Español
 //TODO Translate [Reference] 'Flour! Flour! Where did I put that flour?'
-staxel.village.dialogue.job.Patissier.line:10000100=
+staxel.village.dialogue.job.Patissier.line:10000100=¡Harina! ¡Harina! ¿Dónde puse la harina?
 //TODO Translate [Reference] '^c:1486b0;{0-playername}^c:pop;, have you seen my flour?'
-staxel.village.dialogue.job.Patissier.line:10000200=
+staxel.village.dialogue.job.Patissier.line:10000200=¿^c:1486b0;{0-playername}^c:pop;, has visto mi harina?
 //TODO Translate [Reference] 'Oh! I see it!'
-staxel.village.dialogue.job.Patissier.line:10000300=
+staxel.village.dialogue.job.Patissier.line:10000300=¡Oh! ¡Ya la ví!
 //TODO Translate [Reference] 'These cookies are going to be the best yet!'
-staxel.village.dialogue.job.Patissier.line:10000400=
+staxel.village.dialogue.job.Patissier.line:10000400=¡Estas galletas serán las mejores hasta el momento!
 //TODO Translate [Reference] 'I just know it!'
-staxel.village.dialogue.job.Patissier.line:10000500=
+staxel.village.dialogue.job.Patissier.line:10000500=¡Simplemente lo sé!
 //TODO Translate [Reference] '🎶I wish I was on yonder hill🎶'
-staxel.village.dialogue.job.Patissier.line:10000600=
+staxel.village.dialogue.job.Patissier.line:10000600=🎶Deseo estar en esa colina de allá🎶
 //TODO Translate [Reference] 'Oh! Please forgive my tuneless wailing...'
-staxel.village.dialogue.job.Patissier.line:10000700=
+staxel.village.dialogue.job.Patissier.line:10000700=¡Oh! Porfavor, perdona mis gritos desafinados...
 //TODO Translate [Reference] 'I always sing while I'm baking!'
-staxel.village.dialogue.job.Patissier.line:10000800=
+staxel.village.dialogue.job.Patissier.line:10000800=¡Siempre canto mientras horneo!
 //TODO Translate [Reference] 'My apron has been getting a bit worn lately.'
-staxel.village.dialogue.job.Patissier.line:10000900=
+staxel.village.dialogue.job.Patissier.line:10000900=Mi delantal se ha deteriorado un poco últimamente.
 //TODO Translate [Reference] 'I should probably think about having a new one made.'
-staxel.village.dialogue.job.Patissier.line:10001000=
+staxel.village.dialogue.job.Patissier.line:10001000=Debería pensar en hacerme uno nuevo.
 //TODO Translate [Reference] 'Maybe a lacy or frilly one?'
-staxel.village.dialogue.job.Patissier.line:10001100=
+staxel.village.dialogue.job.Patissier.line:10001100=¿Quizás uno con encajes o uno bordado?
 //TODO Translate [Reference] '🎶 ...sage, rosemary, and thyme... 🎶'
-staxel.village.dialogue.job.Patissier.line:10001200=
+staxel.village.dialogue.job.Patissier.line:10001200=🎶...sabio, romero y tomillo...🎶
 //TODO Translate [Reference] 'No, no. While I do know at least a thousand recipes for strawberry shortcake...'
-staxel.village.dialogue.job.Patissier.line:10001300=
+staxel.village.dialogue.job.Patissier.line:10001300=No, no. A pesar de que conozco al menos mil recetas para la tarta de fresa...
 //TODO Translate [Reference] 'That isn't one of them!'
-staxel.village.dialogue.job.Patissier.line:10001400=
+staxel.village.dialogue.job.Patissier.line:10001400=¡Esa no es una de ellas!
 //TODO Translate [Reference] 'Some parts of my baking are a bit of a mystery...'
-staxel.village.dialogue.job.Patissier.line:10001500=
+staxel.village.dialogue.job.Patissier.line:10001500=Algunas pasos en mis preparaciones son un poco misteriosos...
 //TODO Translate [Reference] 'If I don't sing while I work, my pastries don't end up as light and crispy!'
-staxel.village.dialogue.job.Patissier.line:10001600=
+staxel.village.dialogue.job.Patissier.line:10001600=¡Si no canto mientras trabajo, mis pasteles no quedan tan vivos y crujientes!
 //TODO Translate [Reference] 'It's almost like the songs are charms for making good sweets!'
-staxel.village.dialogue.job.Patissier.line:10001700=
+staxel.village.dialogue.job.Patissier.line:10001700=¡Es como si las canciones fueran hechizos para hacer buenos dulces!
 //TODO Translate [Reference] 'If you buy an ^c:d03e37;oven^c:pop; you can ^c:d03e37;bake^c:pop; all sorts of things.'
-staxel.village.dialogue.job.Patissier.line:10001800=
+staxel.village.dialogue.job.Patissier.line:10001800=Si compras un ^c:d03e37;horno^c:pop; puedes ^c:d03e37;hornear^c:pop; todo tipo de cosas.
 //TODO Translate [Reference] 'There are lots of people in the village who might appreciate it!'
-staxel.village.dialogue.job.Patissier.line:10001900=
+staxel.village.dialogue.job.Patissier.line:10001900=¡Hay muchas personas en la villa que lo apreciarían!
 //TODO Translate [Reference] 'I can't bake everything for everyone after all!'
-staxel.village.dialogue.job.Patissier.line:10002000=
+staxel.village.dialogue.job.Patissier.line:10002000=¡No puedo hornear todo para todos, después de todo!
 //TODO Translate [Reference] 'I'm only one person, even if I am cute!'
-staxel.village.dialogue.job.Patissier.line:10002100=
+staxel.village.dialogue.job.Patissier.line:10002100=¡A pesar de ser atractivo, sólo soy una persona!
 //TODO Translate [Reference] 'I'm starting to get tired of baking round macaroons.'
-staxel.village.dialogue.job.Patissier.line:10002200=
+staxel.village.dialogue.job.Patissier.line:10002200=Me estoy empezando a cansar de hornear macarrones redondos.
 //TODO Translate [Reference] 'I think I'll make the next batch heart-shaped.'
-staxel.village.dialogue.job.Patissier.line:10002300=
+staxel.village.dialogue.job.Patissier.line:10002300=Creo que haré el próximo lote con forma de corazón.
 //TODO Translate [Reference] 'I really want to bake a princess cake, but we don't have any princesses...'
-staxel.village.dialogue.job.Patissier.line:10002400=
+staxel.village.dialogue.job.Patissier.line:10002400=Realmente me encantaría hornear un pastel para una princesa, pero no tenemos ninguna princesa...
 //TODO Translate [Reference] 'Do you think ^c:1486b0;{0-mayor_name}^c:pop; would agree to dress up as one for a day?'
-staxel.village.dialogue.job.Patissier.line:10002500=
+staxel.village.dialogue.job.Patissier.line:10002500=¿Crees que el ^c:1486b0;{0-mayor_name}^c:pop; estaría de acuerdo en vestir como una por un día?


### PR DESCRIPTION
Hello, here I'm pulling the spanish translation for these files: `MerchantHelp_es_ES.lang`, `NerdGeneral_es_ES.lang`, `NerdTheft_es_ES.lang`, `OrderlyGeneral_es_ES.lang`, `PatisserieMissing_es_ES.lang`, and `PatissierJob_es_ES.lang`.

- 1096 translatable words have been translated to spanish (not counting codes, links, paths nor words that are suposed to remain untranslated)

I will continue to translate the whole `es_ES` folder, only that I'll be pulling every time I get to a 1000 words. I hope this is ok. Thank you!