### PR TITLE
Update Barkeep_ja_JP.lang Japanese Translation

### DIFF
--- a/ja-JP/Barkeep_ja_JP.lang
+++ b/ja-JP/Barkeep_ja_JP.lang
@@ -13,11 +13,11 @@ staxel.village.dialogue.Barkeep.line:10000220=今日はどうしたんだい？
 //[Reference] 'Let's chat!'
 staxel.village.dialogue.Barkeep.line:10000250=話をしよう！
 //[Reference] 'Any rumours?'
-staxel.village.dialogue.Barkeep.line:10000255=なにかウワサ話はないかい？
+staxel.village.dialogue.Barkeep.line:10000255=なにかうわさ話はないかい？
 //[Reference] 'I'm thirsty.'
 staxel.village.dialogue.Barkeep.line:10000260=飲み物が欲しい。
 //[Reference] 'Nothing really.'
-staxel.village.dialogue.Barkeep.line:10000265=特に無い。
+staxel.village.dialogue.Barkeep.line:10000265=特にない。
 //[Reference] 'I'm sure you'll fit right in.'
 staxel.village.dialogue.Barkeep.line:10000300=この町はキミにピッタリのはずさ。
 //[Reference] 'Here, this is on the house!'
@@ -35,9 +35,9 @@ staxel.village.dialogue.Barkeep.line:10000630=ネコは最高にかわいい！
 //[Reference] 'Dogs are the coolest!'
 staxel.village.dialogue.Barkeep.line:10000640=イヌが一番かっこいい！
 //[Reference] 'Oh! How lucky for you!'
-staxel.village.dialogue.Barkeep.line:10000650=おお！君は運が良い！
+staxel.village.dialogue.Barkeep.line:10000650=おお！君は運がいい！
 //[Reference] 'A merchant came by the other day whose aunt's friend's sister's son had a litter!'
-staxel.village.dialogue.Barkeep.line:10000660=この前、ある商人が来たんだが、その叔母の友達の妹のところに生まれたペットがいるそうだ！
+staxel.village.dialogue.Barkeep.line:10000660=この前、商人が来たんだが、その叔母の友達の妹のところに生まれたペットがいるそうだ！
 //[Reference] 'If you come back once you're done with ^c:1486b0;{0-tut_name}^c:pop;, I might just have one for you!'
 staxel.village.dialogue.Barkeep.line:10000670=^c:1486b0;{0-tut_name}^c:pop;との作業が終わったら来てくれ。君にその子をあげられるかもしれない！
 //[Reference] 'Good luck!'
@@ -45,9 +45,9 @@ staxel.village.dialogue.Barkeep.line:10000680=がんばれよ！
 //[Reference] 'Hope to see you around!'
 staxel.village.dialogue.Barkeep.line:10002600=またな！
 //[Reference] 'Hmm... doesn't look like there's much going on right now.'
-staxel.village.dialogue.Barkeep.line:10002700=うーん…今の所は特に無いな。
+staxel.village.dialogue.Barkeep.line:10002700=うーん…今の所は特にないな。
 //[Reference] 'I haven't heard any rumours today.'
-staxel.village.dialogue.Barkeep.line:10002800=今日はウサワ話をなにも聞いていないな。
+staxel.village.dialogue.Barkeep.line:10002800=今日はうわさ話をなにも聞いていないな。
 //[Reference] 'Supposedly ^c:1486b0;{0-quest_giver_0}^c:pop; is having a little trouble.'
 staxel.village.dialogue.Barkeep.line:10002900=^c:1486b0;{0-quest_giver_0}^c:pop;が少し問題を抱えているらしい。
 //[Reference] 'Seems things aren't perfect for ^c:1486b0;{0-quest_giver_1}^c:pop; either.'


### PR DESCRIPTION
「うわさ」「ウワサ」「ウサワ」とひらがなとカタカナが混在・誤字があったものを修正しました。
その他、日本語的に自然な言い方になるように修正しました。