### PR TITLE
FIXED MISSING ARGUMENTS AND VALIDATED: pt-BR/CaithWitch_pt_BR.lang

### DIFF
--- a/pt-BR/CaithWitch_pt_BR.lang
+++ b/pt-BR/CaithWitch_pt_BR.lang
@@ -65,7 +65,7 @@ staxel.village.dialogue.CaithWitch.line:10003000=Que tal a gente se apresentar?
 //[Reference] 'There aren't many people like ^c:1486b0;{0-name}^c:pop; out there!'
 staxel.village.dialogue.CaithWitch.line:10003100=Não há muitas pessoas como ^c:1486b0;{0-name}^c:pop; por aí!
 //[Reference] 'Father flew away so ^c:1486b0;{0-name}^c:pop; followed...'
-staxel.village.dialogue.CaithWitch.line:10003200=O pai de ^c:1486b0;{0-name}^c:pop; voou pra longe, então ^c:1486b0;{0-name}^c:pop; foi atrás...
+staxel.village.dialogue.CaithWitch.line:10003200=O pai de ^c:1486b0;{0-name}^c:pop; voou pra longe, então ele foi atrás...
 //[Reference] 'But flying this far was a bit more...costly than expected...mya.'
 staxel.village.dialogue.CaithWitch.line:10003300=Mas voar tanto assim foi mais... cansativo do que eu esperava... miau.
 //[Reference] 'Would you happen to have seen him around?'

--- a/pt-BR/CaithWitch_pt_BR.lang
+++ b/pt-BR/CaithWitch_pt_BR.lang
@@ -200,7 +200,6 @@ staxel.village.dialogue.CaithWitch.line:10009700=Será... será que você poderi
 staxel.village.dialogue.CaithWitch.line:10009800=Tem muitas árvores grandes e ocas na ^c:1486b0;pradaria^c:pop;! Uma dessas seria ideal!
 //[Reference] 'As long as it's not in the ^c:1486b0;village^c:pop;, ^c:1486b0;{0-name}^c:pop; will be happy!'
 staxel.village.dialogue.CaithWitch.line:10009900=Desde que não seja no ^c:1486b0;vilarejo^c:pop;, ^c:1486b0;{0-name}^c:pop; ficará muito contente!
-//[Validate] Delete this comment if or when the translation is accurate.
 //[Reference] 'Ooooh... ^c:1486b0;{0-name}'s^c:pop; back hurts, mya...'
 staxel.village.dialogue.CaithWitch.line:10010000=Aaaah... que dor nas costas, que ^c:1486b0;{0-name}^c:pop; está sentindo, miau...
 //[Reference] 'A comfortable bed...that's all she asks...'
@@ -383,7 +382,6 @@ staxel.village.dialogue.CaithWitch.line:10018800=Hum... ^c:1486b0;{0-name}^c:pop
 staxel.village.dialogue.CaithWitch.line:10018900=Mas deve servir.
 //[Reference] 'That ^c:1486b0;magic potion^c:pop; should do the trick.'
 staxel.village.dialogue.CaithWitch.line:10019000=Essa ^c:1486b0;poção mágica^c:pop; deve funcionar.
-//[Validate] Delete this comment if or when the translation is accurate.
 //[Reference] 'Perhaps you should tell father to come himself next time?'
 staxel.village.dialogue.CaithWitch.line:10019100=Pode dizer ao pai pra ele vir pessoalmente na próxima vez?
 //[Reference] 'Also, I made some extra ^c:1486b0;seeds^c:pop;. These are not as powerful, but you should find them to your liking.'


### PR DESCRIPTION
CaithWitch_pt_BR.lang : Invalid arg: {0-name} in line : staxel.village.dialogue.CaithWitch.line:10003200 was corrected.