### PR TITLE
Update tileobject_de_DE.lang

### DIFF
--- a/de-DE/tileobject_de_DE.lang
+++ b/de-DE/tileobject_de_DE.lang
@@ -2091,9 +2091,9 @@ staxel.tileObject.serverVillage.Fridge.description=Wird zur Aufbewahrung deines 
 //[Reference] 'Simply Freezing Fridge'
 staxel.tileObject.serverVillage.Fridge.name=Einfacher Gefrierkühlschrank
 //[Reference] 'This station is for frying anything a recipe calls for.'
-staxel.tileObject.serverVillage.FryingStation.description=In dieser Frittierstation kann man einfach alles frittieren.
+staxel.tileObject.serverVillage.FryingStation.description=In dieser Bratstation kann man einfach alles braten.
 //[Reference] 'Frying Station'
-staxel.tileObject.serverVillage.FryingStation.name=Frittierstation
+staxel.tileObject.serverVillage.FryingStation.name=Bratstation
 //[Reference] 'Don't just leave your garbage lying around, there's a special place for that.'
 staxel.tileObject.serverVillage.GarbageBin.description=Lass deinen Müll nicht einfach herumliegen, entsorge ihn an der dafür geeigneten Stelle.
 //[Reference] 'Blue Trash Can'


### PR DESCRIPTION
Changed frittieren to braten. Frittieren is deep frying food in a large pot of oil. Braten is cooking food with heat on a flat surface, such as a frypan (bratpfanne).